### PR TITLE
fix: prevent path traversal in API host details endpoint

### DIFF
--- a/api.py
+++ b/api.py
@@ -192,7 +192,16 @@ def apiv1_hostdetails(request, scanfile, faddress=""):
 	if token_check(request.GET['token']) is not True:
 		return HttpResponse(json.dumps({'error':'invalid token'}, indent=4), content_type="application/json")
 
-	oo = xmltodict.parse(open('/opt/xml/'+scanfile, 'r').read())
+	# Prevent path traversal: only allow safe filenames
+	scanfile = os.path.basename(scanfile)
+	if '..' in scanfile or '/' in scanfile or '\\' in scanfile:
+		return HttpResponse(json.dumps({'error':'invalid scanfile'}, indent=4), content_type="application/json")
+
+	xml_path = os.path.join('/opt/xml/', scanfile)
+	if not os.path.exists(xml_path):
+		return HttpResponse(json.dumps({'error':'file not found'}, indent=4), content_type="application/json")
+
+	oo = xmltodict.parse(open(xml_path, 'r').read())
 	out2 = json.dumps(oo['nmaprun'], indent=4)
 	o = json.loads(out2)
 


### PR DESCRIPTION
## Summary

Prevent path traversal in the `apiv1_hostdetails` API endpoint by sanitizing the `scanfile` URL parameter.

## Problem

The `apiv1_hostdetails` function uses the `scanfile` URL path parameter directly in a file open call:

```python
def apiv1_hostdetails(request, scanfile, faddress=""):
    oo = xmltodict.parse(open('/opt/xml/'+scanfile, 'r').read())
```

An attacker can read arbitrary files using path traversal:
- `/api/v1/scan/../../etc/passwd/hosts` → reads `/etc/passwd`

## Fix

- Use `os.path.basename(scanfile)` to strip directory components
- Validate no path traversal characters remain
- Use `os.path.join` for safe path construction
- Add file existence check

## Impact

- **Type**: Path Traversal / Arbitrary File Read (CWE-22)
- **Affected endpoint**: `/api/v1/scan/{scanfile}/hosts`
- **Risk**: Read any file on the server
- **OWASP**: A01:2021 — Broken Access Control