### PR TITLE
feat: add clickable hyperlinks for HTTP/HTTPS open ports

### DIFF
--- a/templates/nmapreport/nmap_portdetails.html
+++ b/templates/nmapreport/nmap_portdetails.html
@@ -39,6 +39,25 @@
 										<i class="fas fa-door-open green-text"></i>
 									{% endif %}
 									<span class="title-small grey-text">{{ v.protocol }} / </span><b class="blue-text text-darken-3">{{ v.portid }}</b><br>
+{% if v.state == "open" %}
+    {% if v.portid == "80" or v.portid == "8080" or v.portid == "3000" or v.portid == "8000" %}
+        <a href="http://{{ address }}:{{ v.portid }}" target="_blank" class="small green-text">
+            <i class="fas fa-external-link-alt"></i> http://{{ address }}:{{ v.portid }}
+        </a>
+    {% elif v.portid == "443" or v.portid == "8443" %}
+        <a href="https://{{ address }}:{{ v.portid }}" target="_blank" class="small green-text">
+            <i class="fas fa-external-link-alt"></i> https://{{ address }}:{{ v.portid }}
+        </a>
+    {% elif v.service == "http" %}
+        <a href="http://{{ address }}:{{ v.portid }}" target="_blank" class="small green-text">
+            <i class="fas fa-external-link-alt"></i> http://{{ address }}:{{ v.portid }}
+        </a>
+    {% elif v.service == "https" %}
+        <a href="https://{{ address }}:{{ v.portid }}" target="_blank" class="small green-text">
+            <i class="fas fa-external-link-alt"></i> https://{{ address }}:{{ v.portid }}
+        </a>
+    {% endif %}
+{% endif %}
 									<div class="small" style="margin-top:10px;">
 										<b class="grey-text">Service:</b> {{ v.service }}<br>
 										<b class="grey-text">State:</b> {{ v.state }}<br>


### PR DESCRIPTION
 What does this PR do?
Adds clickable hyperlinks for open HTTP and HTTPS ports in the port details view.

 Why is this needed?
makes it easy to open web services directly from the WebMap dashboard with one click.

 Changes Made
- Port 80, 8080, 3000, 8000 → clickable http:// link
- Port 443, 8443 → clickable https:// link
- Ports with service detected as http/https → clickable link
- Links open in a new tab
- Only shown for open ports
#34 resolved